### PR TITLE
Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Usage with default slices
 ### With Sass modules and @use, recommended
 
 ```scss
-@use "node_modules/breakpoint-slicer" as bs;
+@use "node_modules/breakpoint-slicer" as bp;
 
 .foo {
   @include bp.at(s) {


### PR DESCRIPTION
At least I presume this was a typo. 🤷🏻‍♂️ Regardless, I think "slice" would be a better name for the purpose of your examples and in conjunction with the invocation of mixins... "slice.from" and "slice.between". 

@include slice.at(small) {
    color: red;
  }